### PR TITLE
Rename images

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -52,9 +52,7 @@ jobs:
       matrix:
         include:
           - context: frontend
-            image: frontend
           - context: core
-            image: core
     permissions:
       contents: read
       packages: write
@@ -74,7 +72,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/${{ matrix.image }}
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/${{ matrix.context }}
           tags: |
             type=ref,event=pr
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -52,9 +52,9 @@ jobs:
       matrix:
         include:
           - context: frontend
-            image: scystream-frontend
+            image: frontend
           - context: core
-            image: scystream-core
+            image: core
     permissions:
       contents: read
       packages: write
@@ -112,7 +112,7 @@ jobs:
       - name: SSH Deploy
         run: |
           ssh -i ~/id_rsa -o StrictHostKeyChecking=no ${{ secrets.SERVER_USER }}@${{ secrets.SERVER_HOSTNAME }} << 'EOF'
-            docker pull ${{ env.REGISTRY }}/rwth-time/scystream/scystream-frontend:latest
-            docker pull ${{ env.REGISTRY }}/rwth-time/scystream/scystream-core:latest
+            docker pull ${{ env.REGISTRY }}/rwth-time/scystream/frontend:latest
+            docker pull ${{ env.REGISTRY }}/rwth-time/scystream/core:latest
             docker compose down && docker compose up -d
           EOF


### PR DESCRIPTION
I felt it was pretty annoying that the images were called `scystream/scystream-frontend` and `scystream/scystream-core` they should rather be called `scystream/frontend` and `scystream/core`. 

- [ ] Be aware to change the `docker-compose.yml` on `prod` to the right image names after this has been merged!
- [ ] Also make sure to remove the old images