### PR TITLE
fix: relationsip model loading

### DIFF
--- a/core/services/user_service/models/user.py
+++ b/core/services/user_service/models/user.py
@@ -5,6 +5,8 @@ from sqlalchemy.orm import relationship
 import uuid
 
 from utils.database.connection import Base
+from services.workflow_service.models.user_project import UserProject
+from services.workflow_service.models.project import Project
 
 
 class User(Base):
@@ -14,5 +16,5 @@ class User(Base):
     email = Column(String, unique=True, nullable=False)
     password = Column(LargeBinary, nullable=False)
 
-    projects = relationship("Project", secondary="user_project",
+    projects = relationship(Project, secondary=UserProject.__tablename__,
                             back_populates="users")

--- a/core/services/workflow_service/models/project.py
+++ b/core/services/workflow_service/models/project.py
@@ -6,6 +6,7 @@ import uuid
 
 from datetime import datetime
 from utils.database.connection import Base
+from .block import Block
 
 
 class Project(Base):
@@ -19,5 +20,5 @@ class Project(Base):
     users = relationship("User", secondary="user_project",
                          back_populates="projects")
 
-    blocks = relationship("Block", back_populates="project",
+    blocks = relationship(Block, back_populates="project",
                           cascade="all, delete-orphan")


### PR DESCRIPTION
I found an issue with the code. Using string relationships for the User model didn't work as expected because the Project and Block models also needed to be loaded in order to be accessed by SQLAlchemy when setting up the relationship.

It's a bit inconvenient.
@mottegk, we both should keep in mind to use the model classes directly wherever possible, without causing circular imports.